### PR TITLE
Upgrade Docker and buildx with version pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.17 as build
 
 ARG BUILD_SHA
 
@@ -8,22 +8,14 @@ COPY dockerproxy .
 
 RUN GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -o dockerproxy -ldflags "-X main.gitSha=$BUILD_SHA -X main.buildTime=$(date +'%Y-%m-%dT%TZ')"
 
-FROM alpine as buildx
-
-RUN apk add curl jq
-
-RUN mkdir -p /root/.docker/cli-plugins
-RUN curl -L https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > /root/.docker/cli-plugins/docker-buildx
-RUN chmod a+x /root/.docker/cli-plugins/docker-buildx
-
-FROM docker:20
+FROM docker:20.10.12-alpine3.15
 
 RUN apk add bash ip6tables pigz sysstat procps lsof
 
 COPY etc/docker/daemon.json /etc/docker/daemon.json
 
-COPY --from=buildx /root/.docker /root/.docker
 COPY --from=build /app/dockerproxy /dockerproxy
+COPY --from=docker/buildx-bin:v0.7 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 COPY ./entrypoint ./entrypoint
 COPY ./docker-entrypoint.d/* ./docker-entrypoint.d/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Build manually for pushing dev releases
+#
+
+REPO=flyio/rchab:$1
+docker build --platform linux/amd64 --build-arg=$(git rev-parse HEAD) -t $REPO .
+docker push $REPO

--- a/docker-entrypoint.d/docker
+++ b/docker-entrypoint.d/docker
@@ -5,7 +5,4 @@ set -e
 echo "Setting up Docker data directory"
 mkdir -p /data/docker
 
-echo "Configuring ipv6 for docker"
-ip6tables -t nat -A POSTROUTING -s 2001:db8:1::/64 ! -o docker0 -j MASQUERADE
-
 echo "Done setting up docker!"

--- a/etc/docker/daemon.json
+++ b/etc/docker/daemon.json
@@ -1,6 +1,8 @@
 {
     "data-root": "/data/docker",
+    "experimental": true,
     "ipv6": true,
+    "ip6tables": true,
     "fixed-cidr-v6": "2001:db8:1::/64",
     "default-address-pools": [
         {


### PR DESCRIPTION
Docker and buildx were behind, so we upgrade them and pin to specific versions. After this we can start with versioned releases of this project so we know which one is being used by a builder machine.