### PR TITLE
Add Nix build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN apk add bash ip6tables pigz sysstat procps lsof util-linux-misc xz curl sudo
 
 RUN curl -L https://github.com/DarthSim/hivemind/releases/download/v1.0.6/hivemind-v1.0.6-linux-amd64.gz -o hivemind.gz \
   && gunzip hivemind.gz \
-  && mv hivemind /usr/local/bin
+  && mv hivemind /usr/local/bin \
+  && chmod 755 /usr/local/bin/hivemind
 
 # Required for Nix to function as root
 ENV USER root
@@ -41,4 +42,4 @@ ENV DOCKER_TMPDIR=/data/docker/tmp
 
 ENTRYPOINT ["./entrypoint"]
 
-CMD ["hivemind", "Procfile"]
+CMD ["/usr/local/bin/hivemind", "./Procfile"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+dockerproxy: ./dockerproxy
+rsyncd: rsync --daemon --no-detach --log-file=/dev/stdout

--- a/create_nix_users.sh
+++ b/create_nix_users.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+CPUS=$(nproc)
+addgroup nixbld
+for num in `seq 1 $CPUS`; do
+  adduser --disabled-password nixbld${num} -G nixbld
+done

--- a/docker-entrypoint.d/nix
+++ b/docker-entrypoint.d/nix
@@ -20,7 +20,7 @@ if [ -z "$(ls -A $NIX_DIR)" ]; then
   rsync -av /nix/* $NIX_DIR
 fi
 
-if [ -z "$(ls -A $NIX_DIR)" ]; then
+if [ -z "$(ls -A $ROOT_HOME_DIR)" ]; then
   echo "The persistent root home directory is empty, so bootstrap it from the image."
   rsync -av /root/* $ROOT_HOME_DIR
 fi

--- a/docker-entrypoint.d/nix
+++ b/docker-entrypoint.d/nix
@@ -17,12 +17,12 @@ mkdir -p $NIX_DIR
 
 if [ -z "$(ls -A $NIX_DIR)" ]; then
   echo "The persistent nix store is empty, so bootstrap it from the image."
-  rsync -av /nix/* $NIX_DIR
+  rsync -av /nix/ $NIX_DIR
 fi
 
 if [ -z "$(ls -A $ROOT_HOME_DIR)" ]; then
   echo "The persistent root home directory is empty, so bootstrap it from the image."
-  rsync -av /root/* $ROOT_HOME_DIR
+  rsync -av /root/ $ROOT_HOME_DIR
 fi
 
 echo "Bind-mounting persistent nix store to /nix."

--- a/docker-entrypoint.d/nix
+++ b/docker-entrypoint.d/nix
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+DATA_DIR=${DATA_DIR:-/data}
+NIX_DIR=${DATA_DIR}/nix
+ROOT_HOME_DIR=${DATA_DIR}/root
+
+# Create the rsync target directory for housing build source
+mkdir -p ${DATA_DIR}/source
+
+# Create a persistent root home directory for storing Nix-related directories
+mkdir -p $ROOT_HOME_DIR
+
+# Create the persistent Nix store directory
+mkdir -p $NIX_DIR
+
+if [ -z "$(ls -A $NIX_DIR)" ]; then
+  echo "The persistent nix store is empty, so bootstrap it from the image."
+  rsync -av /nix/* $NIX_DIR
+fi
+
+if [ -z "$(ls -A $NIX_DIR)" ]; then
+  echo "The persistent root home directory is empty, so bootstrap it from the image."
+  rsync -av /root/* $ROOT_HOME_DIR
+fi
+
+echo "Bind-mounting persistent nix store to /nix."
+mount --bind $NIX_DIR /nix
+
+echo "Bind-mounting persistent root home directory to /root."
+mount --bind $ROOT_HOME_DIR /root

--- a/rsyncd.conf
+++ b/rsyncd.conf
@@ -1,7 +1,7 @@
 uid = root
 gid = root
 
-[source]
+[data]
   path = /data/source
   comment = source
   read only = false

--- a/rsyncd.conf
+++ b/rsyncd.conf
@@ -1,0 +1,7 @@
+uid = root
+gid = root
+
+[source]
+  path = /data/source
+  comment = source
+  read only = false


### PR DESCRIPTION
This PR sets up the Nix store, build tools and `rsyncd` for receiving source trees to be built. The Nix store ultimately persists on the builder dedicated volume, and build artifacts will be cached in the store. A next step should be to run periodic Nix garbage collection.

Related CLI PR: https://github.com/superfly/flyctl/pull/845