### PR TITLE
Configure our docker hub mirror

### DIFF
--- a/etc/docker/daemon.json
+++ b/etc/docker/daemon.json
@@ -23,5 +23,8 @@
     "max-concurrent-downloads": 10,
     "max-concurrent-uploads": 5,
     "metrics-addr": "0.0.0.0:9323",
-    "tls": false
+    "tls": false,
+    "registry-mirrors": [
+        "https://hub-mirror.registry.fly.io"
+    ]
 }


### PR DESCRIPTION
Adds our docker hub mirror.

Docs: https://docs.docker.com/registry/recipes/mirror/
PR: https://github.com/superfly/bubblegum/pull/23
test rchab image: https://hub.docker.com/repository/docker/michaeldwan/rchab
