### PR TITLE
Upgrade both docker and buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY dockerproxy .
 
 RUN GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -o dockerproxy -ldflags "-X main.gitSha=$BUILD_SHA -X main.buildTime=$(date +'%Y-%m-%dT%TZ')"
 
-FROM docker:20.10.12-alpine3.15
+FROM docker:20.10.17-alpine3.16
 
 RUN apk add bash ip6tables pigz sysstat procps lsof util-linux-misc xz curl sudo rsync
 
@@ -30,7 +30,7 @@ RUN ln -s /root/.nix-profile/etc/profile.d/nix.sh /etc/profile.d/nix.sh
 COPY etc/docker/daemon.json /etc/docker/daemon.json
 
 COPY --from=build /app/dockerproxy /dockerproxy
-COPY --from=docker/buildx-bin:v0.7 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --from=docker/buildx-bin:v0.8 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 COPY ./entrypoint ./entrypoint
 COPY ./docker-entrypoint.d/* ./docker-entrypoint.d/


### PR DESCRIPTION
`buildx` uses a much more recent `buildkit` which hopefully fixes a few bugs we've encountered.