### PR TITLE
Trap SIGUSR1

### DIFF
--- a/dockerproxy/main.go
+++ b/dockerproxy/main.go
@@ -60,6 +60,12 @@ var bufPool = sync.Pool{
 const DOCKER_SOCKET_PATH = "/var/run/docker.sock"
 
 func main() {
+	keepAliveSig := make(chan os.Signal, 1)
+	signal.Notify(
+		keepAliveSig,
+		syscall.SIGUSR1,
+	)
+
 	lvl, err := logrus.ParseLevel(os.Getenv("LOG_LEVEL"))
 	if err != nil {
 		lvl = logrus.InfoLevel
@@ -69,12 +75,6 @@ func main() {
 		TimestampFormat: "2006-01-02T15:04:05.000000000Z07:00",
 		FullTimestamp:   true,
 	})
-
-	keepAliveSig := make(chan os.Signal, 1)
-	signal.Notify(
-		keepAliveSig,
-		syscall.SIGUSR1,
-	)
 
 	log.Infof("Build SHA:%s Time:%s", gitSha, buildTime)
 

--- a/dockerproxy/main.go
+++ b/dockerproxy/main.go
@@ -70,6 +70,12 @@ func main() {
 		FullTimestamp:   true,
 	})
 
+	keepAliveSig := make(chan os.Signal, 1)
+	signal.Notify(
+		keepAliveSig,
+		syscall.SIGUSR1,
+	)
+
 	log.Infof("Build SHA:%s Time:%s", gitSha, buildTime)
 
 	api.SetBaseURL("https://api.fly.io")
@@ -116,12 +122,6 @@ func main() {
 	)
 
 	var killSignaled bool
-
-	keepAliveSig := make(chan os.Signal, 1)
-	signal.Notify(
-		keepAliveSig,
-		syscall.SIGUSR1,
-	)
 
 ALIVE:
 	for {

--- a/entrypoint
+++ b/entrypoint
@@ -2,6 +2,8 @@
 
 set -e
 
+trap 'echo "Received premature SIGUSR1"' SIGUSR1
+
 if [[ -d "docker-entrypoint.d" ]]
 then
 echo "Running docker-entrypoint.d files"


### PR DESCRIPTION
If 2 builds are triggered at the same time, it's possible for a SIGUSR1 to be sent before we're intercepting it in the `dockerproxy`.

This PR traps it in the entrypoint and then first thing in the `dockerproxy`. This should prevent almost every race in intercepting SIGUSR1 resulting in the unwanted kill of the builder's main process.