### PR TITLE
updated docker to version 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,18 @@ COPY dockerproxy .
 
 RUN GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -o dockerproxy -ldflags "-X main.gitSha=$BUILD_SHA -X main.buildTime=$(date +'%Y-%m-%dT%TZ')"
 
-FROM docker:20.10.12-alpine3.15
+FROM docker:24.0.7-alpine3.19
 
-RUN apk add bash ip6tables pigz sysstat procps lsof util-linux-misc xz curl sudo
+RUN apk add bash iptables-legacy pigz sysstat procps lsof util-linux-misc xz curl sudo \
+    && mv /sbin/iptables /sbin/iptables.original \
+    && mv /sbin/ip6tables /sbin/ip6tables.original \
+    && ln -s /sbin/iptables-legacy /sbin/iptables \
+    && ln -s /sbin/ip6tables-legacy /sbin/ip6tables
 
 COPY etc/docker/daemon.json /etc/docker/daemon.json
 
 COPY --from=build /app/dockerproxy /dockerproxy
-COPY --from=docker/buildx-bin:v0.7 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --from=docker/buildx-bin:v0.12 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 COPY ./entrypoint ./entrypoint
 COPY ./docker-entrypoint.d/* ./docker-entrypoint.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,7 @@ RUN GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -o dockerproxy -ldflags "-X ma
 
 FROM docker:24.0.7-alpine3.19
 
-RUN apk add bash iptables-legacy pigz sysstat procps lsof util-linux-misc xz curl sudo \
-    && mv /sbin/iptables /sbin/iptables.original \
-    && mv /sbin/ip6tables /sbin/ip6tables.original \
-    && ln -s /sbin/iptables-legacy /sbin/iptables \
-    && ln -s /sbin/ip6tables-legacy /sbin/ip6tables
+RUN apk add bash pigz sysstat procps lsof util-linux-misc xz curl sudo
 
 COPY etc/docker/daemon.json /etc/docker/daemon.json
 


### PR DESCRIPTION
Supercedes https://github.com/superfly/rchab/pull/15

Withing that PR, Jerome got errors. I believe I resolved those here (or at least I have it working in my own app!). The changes were related to needing an older `iptables` and `ip6tables` package (`apk add iptables-legacy`).

This PR updates Docker to 24, and Buildx to 0.12 (along with AlpineJS under the hood).

I tested this on my own repository, but not in rchab directly. The main difference in my own test repository was:

1. Using `docker:24-dind` base image (this repo never used the `dind` variant and is likely fine without it, this PR does not use it)
2. Running `ip6tables-legacy -t nat -A POSTROUTING -s 2001:db8:1::/64 ! -o docker0 -j MASQUERADE` in the `docker-entrypoint.d/docker` script (which was just a copy/paste/tweak from previous work I did to create my own docker builder app that wasn't the official Fly builder. It likely isn't needed here.)

I **didn't** test this change locally first in this specific repository, mostly because I didn't want to install Vagrant. I can do this work if no one else wants to :P 

