### PR TITLE
wireguardless remote deployments

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,9 @@ Vagrant.configure("2") do |config|
     SHELL
   end
 
+  # Host-only network configuration
+  config.vm.network "private_network", ip: "192.168.50.10"
+  
   # TODO: we probably want to build our own base box here, but that's... work. (tvd, 2022-10-06)
   config.vm.box = "generic/ubuntu1804"
   config.vm.box_version = "4.1.14"
@@ -58,7 +61,7 @@ Vagrant.configure("2") do |config|
 
     goversion=1.21.5
     wget https://go.dev/dl/go${goversion}.linux-amd64.tar.gz
-    echo "aea86e3c73495f205929cfebba0d63f1382c8ac59be081b6351681415f4063cf go${goversion}.linux-amd64.tar.gz" | sha256sum --check
+    echo "e2bc0b3e4b64111ec117295c088bde5f00eeed1567999ff77bc859d7df70078e go${goversion}.linux-amd64.tar.gz" | sha256sum --check
     rm -rf /usr/local/go && tar -C /usr/local -xzf go${goversion}.linux-amd64.tar.gz
     echo 'export PATH=/usr/local/go/bin:$PATH' | tee /etc/profile.d/golang.sh
     /usr/local/go/bin/go version

--- a/dockerproxy/auth.go
+++ b/dockerproxy/auth.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/superfly/flyctl/api"
+)
+
+func authRequest(next http.Handler) http.Handler {
+	if noAuth {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appName, authToken, ok := r.BasicAuth()
+
+		if !ok || !authorizeRequestWithCache(appName, authToken) {
+			w.WriteHeader(http.StatusUnauthorized)
+			err := json.NewEncoder(w).Encode(map[string]string{
+				"message": "You are not authorized to use this builder",
+			})
+			if err != nil {
+				log.Warnln("error writing response", err)
+			}
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func authorizeRequestWithCache(appName, authToken string) bool {
+	if noAuth {
+		return true
+	}
+
+	if appName == "" || authToken == "" {
+		return false
+	}
+
+	cacheKey := appName + ":" + authToken
+	if val, ok := authCache.Get(cacheKey); ok {
+		if authorized, ok := val.(bool); ok {
+			log.Debugln("authorized from cache")
+			return authorized
+		}
+	}
+
+	authorized := authorizeRequest(appName, authToken)
+	authCache.Set(cacheKey, authorized, 0)
+	log.Debugln("authorized from api")
+	return authorized
+}
+
+// TODO: If we know that we're always going to use 6pn to access builders, we can probably just drop this auth since the network will take care to authorize access within the same org?
+func authorizeRequest(appName, authToken string) bool {
+	fly := api.NewClient(authToken, fmt.Sprintf("superfly/rchab/%s", gitSha), "0.0.0.0.0.0.1", log)
+
+	app, err := fly.GetAppCompact(context.TODO(), appName)
+	if app == nil || err != nil {
+		log.Warnf("Error fetching app %s: %v", appName, err)
+		return false
+	}
+
+	// local dev only: we started machine with NO_APP_NAME=1, skip checking that appName from auth is in same org as this builder
+	if noAppName {
+		log.Warnf("Skipping organization check for app %s on builder", appName)
+		return true
+	}
+
+	builderAppName, ok := os.LookupEnv("FLY_APP_NAME")
+	if !ok {
+		log.Warn("FLY_APP_NAME env var is not set!")
+		return false
+	}
+	builderApp, err := fly.GetAppCompact(context.TODO(), builderAppName)
+	if builderApp == nil || err != nil {
+		log.Warnf("Error fetching builder app %s", builderAppName)
+		return false
+	}
+	if app.Organization.ID != builderApp.Organization.ID {
+		log.Warnf("App %s is in %s org, and builder %s is in %s org", appName, app.Organization.Slug, builderAppName, builderApp.Organization.Slug)
+		return false
+	}
+
+	appOrg, err := fly.GetOrganizationBySlug(context.TODO(), app.Organization.Slug)
+	if appOrg == nil || err != nil {
+		log.Warnf("Error fetching org %s: %v", app.Organization.Slug, err)
+		return false
+	}
+	builderOrg, err := fly.GetOrganizationBySlug(context.TODO(), builderApp.Organization.Slug)
+	if builderOrg == nil || err != nil {
+		log.Warnf("Error fetching org %s: %v", builderApp.Organization.Slug, err)
+		return false
+	}
+
+	if app.Organization.ID != builderApp.Organization.ID {
+		log.Warnf("App %s does not belong to org %s (builder app: '%s' builder org: '%s')", app.Name, appOrg.Slug, builderAppName, builderOrg.Slug)
+		return false
+	}
+
+	return true
+}

--- a/dockerproxy/dockerd.go
+++ b/dockerproxy/dockerd.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/mitchellh/go-ps"
+	"github.com/pkg/errors"
+)
+
+func runDockerd() (func() error, *client.Client, error) {
+	// noop
+	if noDockerd {
+		client, err := client.NewClientWithOpts(client.FromEnv)
+		if err != nil {
+			return nil, nil, err
+		}
+		return func() error { return nil }, client, nil
+	}
+
+	// just to be sure, because machines now reuse snapshots
+	os.RemoveAll("/var/run/docker.pid")
+
+	// Launch `dockerd`
+	dockerd := exec.Command("dockerd", "-p", "/var/run/docker.pid")
+	dockerd.Stdout = os.Stderr
+	dockerd.Stderr = os.Stderr
+
+	if err := dockerd.Start(); err != nil {
+		return nil, nil, errors.Wrap(err, "could not start dockerd")
+	}
+
+	cmd := exec.Command("docker", "buildx", "inspect", "--bootstrap")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Warnln("Error bootstrapping buildx builder:", err)
+	}
+
+	dockerDone := make(chan struct{})
+
+	go func() {
+		if err := dockerd.Wait(); err != nil {
+			log.Errorf("error waiting on docker: %v", err)
+		}
+		close(dockerDone)
+	}()
+
+	healthCtx, healthCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer healthCancel()
+
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to setup docker clinet")
+	}
+
+	stopFn := func() error {
+		if dockerd.Process != nil {
+			tryPrune(context.Background(), dockerClient)
+			if err := dockerd.Process.Signal(os.Interrupt); err != nil {
+				return err
+			}
+			<-dockerDone
+			log.Info("dockerd has exited")
+			return nil
+		}
+		return nil
+	}
+
+	for {
+		log.Info("pinging dockerd")
+		resp, err := dockerClient.Ping(healthCtx)
+
+		select {
+		case <-healthCtx.Done():
+			return nil, nil, fmt.Errorf("dockerd failed to boot after 10 seconds")
+		case <-dockerDone:
+			return nil, nil, fmt.Errorf("dockerd exited before we could ascertain its healthyness")
+		default:
+			if err != nil {
+				log.Errorf("failed to ping dockerd: %v", err)
+				time.Sleep(200 * time.Millisecond)
+			}
+			if resp.APIVersion != "" {
+				return stopFn, dockerClient, nil
+			}
+		}
+	}
+}
+
+// buildkit containers don't show up in dockerd, since we're not running
+// buildkitd just look for runc processes which are spawned by buildkit builders
+func isBuildkitActive() (bool, error) {
+	processes, err := ps.Processes()
+	if err != nil {
+		return false, err
+	}
+
+	for _, p := range processes {
+		if p.Executable() == "runc" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func isDockerActive(ctx context.Context, dockerClient *client.Client) (status bool, err error) {
+	containers, err := dockerClient.ContainerList(ctx, types.ContainerListOptions{Filters: filters.NewArgs(filters.Arg("status", "running"))})
+	if err != nil {
+		return false, err
+	}
+	return len(containers) > 0, nil
+}
+
+func watchDocker(ctx context.Context, dockerClient *client.Client, keepaliveCh chan<- struct{}) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			dActive, err := isDockerActive(ctx, dockerClient)
+			if err != nil {
+				log.Error("failed to check for docker activeness", err)
+				return
+			}
+			bActive, err := isBuildkitActive()
+			if err != nil {
+				log.Error("failed to check for buildkit activeness", err)
+				return
+			}
+			if dActive && bActive {
+				keepaliveCh <- struct{}{}
+			}
+		}
+	}
+}

--- a/dockerproxy/main.go
+++ b/dockerproxy/main.go
@@ -2,27 +2,21 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"os/exec"
 	"os/signal"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/gorilla/handlers"
 	"github.com/minio/minio/pkg/disk"
-	"github.com/mitchellh/go-ps"
 	"github.com/patrickmn/go-cache"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/superfly/flyctl/api"
 )
@@ -35,6 +29,7 @@ var (
 	jobDeadline     = time.NewTimer(maxIdleDuration)
 	pendingRequests atomic.Uint64
 	authCache       = cache.New(5*time.Minute, 10*time.Minute)
+	keepAlive       = make(chan struct{})
 
 	//prune
 	pruneThresholdUsedPercent = 0.8
@@ -65,6 +60,16 @@ func main() {
 
 	shutdownChan := make(chan os.Signal, 1)
 	signal.Notify(shutdownChan, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT)
+
+	sigursChan := make(chan os.Signal, 1)
+	signal.Notify(sigursChan, syscall.SIGUSR1)
+
+	go func() {
+		for {
+			<-sigursChan
+			keepAlive <- struct{}{}
+		}
+	}()
 
 	lvl, err := logrus.ParseLevel(os.Getenv("LOG_LEVEL"))
 	if err != nil {
@@ -97,8 +102,11 @@ func main() {
 	go watchDocker(ctx, dockerClient, keepAlive)
 
 	httpMux := http.NewServeMux()
+
 	httpMux.Handle("/", handlers.LoggingHandler(log.Writer(), authRequest(proxy())))
+	httpMux.Handle("/flyio/v1/prune", handlers.LoggingHandler(log.Writer(), authRequest(pruneHandler(dockerClient))))
 	httpMux.Handle("/flyio/v1/extendDeadline", handlers.LoggingHandler(log.Writer(), authRequest(extendDeadline())))
+
 	httpServer := &http.Server{
 		Addr:    ":8080",
 		Handler: httpMux,
@@ -155,284 +163,6 @@ func main() {
 
 	log.Info("shutdown complete")
 	os.Exit(0)
-}
-
-func runDockerd() (func() error, *client.Client, error) {
-	// noop
-	if noDockerd {
-		client, err := client.NewClientWithOpts(client.FromEnv)
-		if err != nil {
-			return nil, nil, err
-		}
-		return func() error { return nil }, client, nil
-	}
-
-	// just to be sure, because machines now reuse snapshots
-	os.RemoveAll("/var/run/docker.pid")
-
-	// Launch `dockerd`
-	dockerd := exec.Command("dockerd", "-p", "/var/run/docker.pid")
-	dockerd.Stdout = os.Stderr
-	dockerd.Stderr = os.Stderr
-
-	if err := dockerd.Start(); err != nil {
-		return nil, nil, errors.Wrap(err, "could not start dockerd")
-	}
-
-	cmd := exec.Command("docker", "buildx", "inspect", "--bootstrap")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Warnln("Error bootstrapping buildx builder:", err)
-	}
-
-	dockerDone := make(chan struct{})
-
-	go func() {
-		if err := dockerd.Wait(); err != nil {
-			log.Errorf("error waiting on docker: %v", err)
-		}
-		close(dockerDone)
-	}()
-
-	healthCtx, healthCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer healthCancel()
-
-	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to setup docker clinet")
-	}
-
-	stopFn := func() error {
-		if dockerd.Process != nil {
-			tryPrune(context.Background(), dockerClient)
-			if err := dockerd.Process.Signal(os.Interrupt); err != nil {
-				return err
-			}
-			<-dockerDone
-			log.Info("dockerd has exited")
-			return nil
-		}
-		return nil
-	}
-
-	for {
-		log.Info("pinging dockerd")
-		resp, err := dockerClient.Ping(healthCtx)
-
-		select {
-		case <-healthCtx.Done():
-			return nil, nil, fmt.Errorf("dockerd failed to boot after 10 seconds")
-		case <-dockerDone:
-			return nil, nil, fmt.Errorf("dockerd exited before we could ascertain its healthyness")
-		default:
-			if err != nil {
-				log.Errorf("failed to ping dockerd: %v", err)
-				time.Sleep(200 * time.Millisecond)
-			}
-			if resp.APIVersion != "" {
-				return stopFn, dockerClient, nil
-			}
-		}
-	}
-}
-
-// tryPrune frees disk space if necessary
-func tryPrune(ctx context.Context, dockerClient *client.Client) {
-	di, err := disk.GetInfo("/data")
-	if err != nil {
-		log.Errorf("could not get disk usage: %v", err)
-		return
-	}
-
-	percentUsed := (float64(di.Total-di.Free) / float64(di.Total))
-	log.Infof("disk space used: %0.2f%%", percentUsed*100)
-	if percentUsed >= pruneThresholdUsedPercent || di.Free <= uint64(pruneThresholdFreeBytes) {
-		log.Info("Not enough disk space, pruning")
-		prune(ctx, dockerClient, "12h")
-	}
-}
-
-func prune(ctx context.Context, dockerClient *client.Client, until string) {
-	imgReport, err := dockerClient.ImagesPrune(ctx, filters.NewArgs(
-		// Remove images created before the duration string (e.g. 12h).
-		filters.Arg("until", until),
-
-		// Remove all images, not just dangling ones.
-		// https://github.com/moby/moby/blob/f117aef2ea63ee008c05a7506c8c9c50a1fa0c7f/docs/api/v1.43.yaml#L8677
-		filters.Arg("dangling", "false"),
-	))
-	if err != nil {
-		log.Errorf("error pruning images: %v", err)
-	} else {
-		log.Infof("Pruned %d bytes of images", imgReport.SpaceReclaimed)
-	}
-
-	volReport, err := dockerClient.VolumesPrune(ctx, filters.NewArgs())
-	if err != nil {
-		log.Errorf("error pruning volumes: %v", err)
-	} else {
-		log.Infof("Pruned %d bytes of volumes", volReport.SpaceReclaimed)
-	}
-
-	bcReport, err := dockerClient.BuildCachePrune(ctx, types.BuildCachePruneOptions{
-		All:     true,
-		Filters: filters.NewArgs(filters.Arg("until", until)),
-	})
-
-	if err != nil {
-		log.Errorf("error pruning build cache: %v", err)
-	} else {
-		log.Infof("Pruned %d bytes from build cache", bcReport.SpaceReclaimed)
-	}
-}
-
-func watchDocker(ctx context.Context, dockerClient *client.Client, keepaliveCh chan<- struct{}) {
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			dActive, err := isDockerActive(ctx, dockerClient)
-			if err != nil {
-				log.Error("failed to check for docker activeness", err)
-				return
-			}
-			bActive, err := isBuildkitActive()
-			if err != nil {
-				log.Error("failed to check for buildkit activeness", err)
-				return
-			}
-			if dActive && bActive {
-				keepaliveCh <- struct{}{}
-			}
-		}
-	}
-}
-
-// buildkit containers don't show up in dockerd, since we're not running
-// buildkitd just look for runc processes which are spawned by buildkit builders
-func isBuildkitActive() (bool, error) {
-	processes, err := ps.Processes()
-	if err != nil {
-		return false, err
-	}
-
-	for _, p := range processes {
-		if p.Executable() == "runc" {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func isDockerActive(ctx context.Context, dockerClient *client.Client) (status bool, err error) {
-	containers, err := dockerClient.ContainerList(ctx, types.ContainerListOptions{Filters: filters.NewArgs(filters.Arg("status", "running"))})
-	if err != nil {
-		return false, err
-	}
-	return len(containers) > 0, nil
-}
-
-func authRequest(next http.Handler) http.Handler {
-	if noAuth {
-		return next
-	}
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		appName, authToken, ok := r.BasicAuth()
-
-		if !ok || !authorizeRequestWithCache(appName, authToken) {
-			if err := writeDockerDaemonResponse2(w, http.StatusUnauthorized, "You are not authorized to use this builder"); err != nil {
-				log.Warnln("error writing response", err)
-			}
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	})
-}
-
-func writeDockerDaemonResponse2(w http.ResponseWriter, status int, message string) error {
-	w.WriteHeader(status)
-	return json.NewEncoder(w).Encode(map[string]string{"message": message})
-}
-
-func authorizeRequestWithCache(appName, authToken string) bool {
-	if noAuth {
-		return true
-	}
-
-	if appName == "" || authToken == "" {
-		return false
-	}
-
-	cacheKey := appName + ":" + authToken
-	if val, ok := authCache.Get(cacheKey); ok {
-		if authorized, ok := val.(bool); ok {
-			log.Debugln("authorized from cache")
-			return authorized
-		}
-	}
-
-	authorized := authorizeRequest(appName, authToken)
-	authCache.Set(cacheKey, authorized, 0)
-	log.Debugln("authorized from api")
-	return authorized
-}
-
-// TODO: If we know that we're always going to use 6pn to access builders, we can probably just drop this auth since the network will take care to authorize access within the same org?
-func authorizeRequest(appName, authToken string) bool {
-	fly := api.NewClient(authToken, fmt.Sprintf("superfly/rchab/%s", gitSha), "0.0.0.0.0.0.1", log)
-
-	app, err := fly.GetAppCompact(context.TODO(), appName)
-	if app == nil || err != nil {
-		log.Warnf("Error fetching app %s: %v", appName, err)
-		return false
-	}
-
-	// local dev only: we started machine with NO_APP_NAME=1, skip checking that appName from auth is in same org as this builder
-	if noAppName {
-		log.Warnf("Skipping organization check for app %s on builder", appName)
-		return true
-	}
-
-	builderAppName, ok := os.LookupEnv("FLY_APP_NAME")
-	if !ok {
-		log.Warn("FLY_APP_NAME env var is not set!")
-		return false
-	}
-	builderApp, err := fly.GetAppCompact(context.TODO(), builderAppName)
-	if builderApp == nil || err != nil {
-		log.Warnf("Error fetching builder app %s", builderAppName)
-		return false
-	}
-	if app.Organization.ID != builderApp.Organization.ID {
-		log.Warnf("App %s is in %s org, and builder %s is in %s org", appName, app.Organization.Slug, builderAppName, builderApp.Organization.Slug)
-		return false
-	}
-
-	appOrg, err := fly.GetOrganizationBySlug(context.TODO(), app.Organization.Slug)
-	if appOrg == nil || err != nil {
-		log.Warnf("Error fetching org %s: %v", app.Organization.Slug, err)
-		return false
-	}
-	builderOrg, err := fly.GetOrganizationBySlug(context.TODO(), builderApp.Organization.Slug)
-	if builderOrg == nil || err != nil {
-		log.Warnf("Error fetching org %s: %v", builderApp.Organization.Slug, err)
-		return false
-	}
-
-	if app.Organization.ID != builderApp.Organization.ID {
-		log.Warnf("App %s does not belong to org %s (builder app: '%s' builder org: '%s')", app.Name, appOrg.Slug, builderAppName, builderOrg.Slug)
-		return false
-	}
-
-	return true
 }
 
 func extendDeadline() http.Handler {
@@ -496,5 +226,17 @@ func proxy() http.Handler {
 		}()
 
 		reverseProxy.ServeHTTP(w, r)
+	})
+}
+
+func pruneHandler(client *client.Client) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		until := strings.TrimSpace(r.URL.Query().Get("since"))
+		if until == "" {
+			until = "1s"
+		}
+
+		prune(r.Context(), client, until)
+		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/dockerproxy/storage.go
+++ b/dockerproxy/storage.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/minio/minio/pkg/disk"
+)
+
+// tryPrune frees disk space if necessary
+func tryPrune(ctx context.Context, dockerClient *client.Client) {
+	di, err := disk.GetInfo("/data")
+	if err != nil {
+		log.Errorf("could not get disk usage: %v", err)
+		return
+	}
+
+	percentUsed := (float64(di.Total-di.Free) / float64(di.Total))
+	log.Infof("disk space used: %0.2f%%", percentUsed*100)
+	if percentUsed >= pruneThresholdUsedPercent || di.Free <= uint64(pruneThresholdFreeBytes) {
+		log.Info("Not enough disk space, pruning")
+		prune(ctx, dockerClient, "12h")
+	}
+}
+
+func prune(ctx context.Context, dockerClient *client.Client, until string) {
+	imgReport, err := dockerClient.ImagesPrune(ctx, filters.NewArgs(
+		// Remove images created before the duration string (e.g. 12h).
+		filters.Arg("until", until),
+
+		// Remove all images, not just dangling ones.
+		// https://github.com/moby/moby/blob/f117aef2ea63ee008c05a7506c8c9c50a1fa0c7f/docs/api/v1.43.yaml#L8677
+		filters.Arg("dangling", "false"),
+	))
+	if err != nil {
+		log.Errorf("error pruning images: %v", err)
+	} else {
+		log.Infof("Pruned %d bytes of images", imgReport.SpaceReclaimed)
+	}
+
+	volReport, err := dockerClient.VolumesPrune(ctx, filters.NewArgs())
+	if err != nil {
+		log.Errorf("error pruning volumes: %v", err)
+	} else {
+		log.Infof("Pruned %d bytes of volumes", volReport.SpaceReclaimed)
+	}
+
+	bcReport, err := dockerClient.BuildCachePrune(ctx, types.BuildCachePruneOptions{
+		All:     true,
+		Filters: filters.NewArgs(filters.Arg("until", until)),
+	})
+
+	if err != nil {
+		log.Errorf("error pruning build cache: %v", err)
+	} else {
+		log.Infof("Pruned %d bytes from build cache", bcReport.SpaceReclaimed)
+	}
+}

--- a/etc/docker/daemon.json
+++ b/etc/docker/daemon.json
@@ -10,8 +10,8 @@
             "size": 24
         }
     ],
-    "debug": true,
-    "log-level": "debug",
+    "debug": false,
+    "log-level": "info",
     "features": {
         "buildkit": true
     },

--- a/fly.toml
+++ b/fly.toml
@@ -1,31 +1,40 @@
-# fly.toml file generated for rchab on 2021-01-08T16:05:33-05:00
+app = 'rchab'
+primary_region = 'ams'
+kill_signal = 'SIGINT'
+kill_timeout = '5s'
 
-app = "rchab"
-
-kill_signal = "SIGINT"
-kill_timeout = 5
-
-[[mounts]]
-source = "data"
-destination = "/data"
-
-[[services]]
-internal_port = 8080
-protocol = "tcp"
-
-[services.concurrency]
-hard_limit = 25
-soft_limit = 20
-
-[[services.ports]]
-handlers = ["tls"]
-port = 10000
+[build]
 
 [env]
-ALLOW_ORG_SLUG = "fly"
-LOG_LEVEL = "debug"
-DATA_DIR = "/data"
+  ALLOW_ORG_SLUG = 'fly'
+  DATA_DIR = '/data'
+  LOG_LEVEL = 'info'
 
-[metrics]
-port = 9323
-path = "/metrics"
+[[mounts]]
+  source = 'data'
+  destination = '/data'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+  [http_service.http_options]
+    h2_backend = true
+    
+  [http_service.tls_options]
+    alpn = ['h2']
+
+
+
+[[vm]]
+  memory = '4gb'
+  cpu_kind = 'shared'
+  cpus = 4
+
+[[metrics]]
+  port = 9323
+  path = '/metrics'


### PR DESCRIPTION
**Idea**
The plan here is to add a new way to communicate with remote builders. 

Currently, we setup a wireguard tunnel into our vm and communicate directly with the docker daemon over http/tcp.

With this feature, we'll bypass wireguard entirely and use https to conduct deployments. Authentication and Authorisation will be done with tkdb (deploy tokens). The general motivation is to make make deployments more reliable by adding another way to communicate with remote builders.

**Flyctl Changes**
https://github.com/superfly/flyctl/pull/3314

**Tasks**
- [x] slap a proxy infront of the docker daemon and run all requests through the proxy
- [x] authorize all requests and limit builders to organizations using tkdb (tbd in different PR) 
- [x] lockdown the docker daemon
    - [ ]  remove the tcp listener and only leave the unix api. We might never do this since we have clients out there in the wild that only know how to build over wireguard)

**Status**
- [2024-02-21] I have a proxy sitting infront of the docker daemon alright. builds work, but pushes hang midway. 
Consistently retrying seems to do the trick, but I want to figure out why the push process stops midway with the error message  `ERRO[2024-02-21T15:04:33.492453604Z] Not continuing with push after error: context canceled`

- [2024-02-29] Running backwards compatibility checks, getting ready for merge.