### PR TITLE
Remove public docker listener and proxy to it in dockerproxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ http://localhost:8080 will have the rchab api in the vm and on your host.
 `flyctl` can be configured to use a locally running version of rchab with:
 
 ```shell
-FLY_REMOTE_BUILDER_HOST_WG=1 FLY_RCHAB_OVERRIDE_HOST=tcp://127.0.0.1:2375 LOG_LEVEL=debug fly deploy --remote-only
+FLY_REMOTE_BUILDER_HOST_WG=1 FLY_RCHAB_OVERRIDE_HOST=tcp://127.0.0.1:2376 LOG_LEVEL=debug fly deploy --remote-only
 ```
 
 * `FLY_REMOTE_BUILDER_HOST_WG` disables usermode wireguard

--- a/etc/docker/daemon.json
+++ b/etc/docker/daemon.json
@@ -17,7 +17,7 @@
     },
     "hosts": [
         "unix:///var/run/docker.sock",
-        "tcp://0.0.0.0:2375"
+        "tcp://127.0.0.1:2376"
     ],
     "mtu": 1400,
     "max-concurrent-downloads": 10,


### PR DESCRIPTION
This addresses a security issue with unauthenticated dockerd being exposed on 6pn by restricting the endpoints that are serviced to just those that are needed by flyctl's deploy builder.

- Move dockerd to localhost port 2376.
- Make dockerproxy proxy 2375 to 2376, with a list of allwed URLs.
