### PR TITLE
always remove pending request, even if path isn't allowed

### DIFF
--- a/dockerproxy/main.go
+++ b/dockerproxy/main.go
@@ -261,6 +261,11 @@ func dockerProxy() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pendingRequests.Add(1)
 
+		defer func() {
+			pendingRequests.Add(^uint64(0))
+		}()
+
+
 		allowed := false
 		for _, allowedPath := range allowedPaths {
 			if allowedPath.MatchString(r.URL.Path) {
@@ -273,10 +278,6 @@ func dockerProxy() http.Handler {
 			http.Error(w, `{"message":"page not found"}`, http.StatusNotFound)
 			return
 		}
-
-		defer func() {
-			pendingRequests.Add(^uint64(0))
-		}()
 
 		reverseProxy.ServeHTTP(w, r)
 	})

--- a/dockerproxy/main.go
+++ b/dockerproxy/main.go
@@ -265,7 +265,6 @@ func dockerProxy() http.Handler {
 			pendingRequests.Add(^uint64(0))
 		}()
 
-
 		allowed := false
 		for _, allowedPath := range allowedPaths {
 			if allowedPath.MatchString(r.URL.Path) {


### PR DESCRIPTION
builders currently won't shutdown if someone makes a request to an unallowed path